### PR TITLE
feat/test: complete ScoreDAO CRUD logic (O02_3)

### DIFF
--- a/src/main/java/org/example/triviagame/ScoreDAO.java
+++ b/src/main/java/org/example/triviagame/ScoreDAO.java
@@ -12,13 +12,14 @@ import java.util.List;
  * Provides Data Access Object (DAO) methods for managing quiz score history,
  * including inserting and retrieving user quiz results through the database.
  *
- * @author Anthony Ou
- * @version 1.0
- * @since 4/12/26
+ * @author Anthony Ou, Yachi Feng
+ * @version 0.2.0
+ * @since 4/22/26
  */
 
 public class ScoreDAO {
     /**
+     * 1. Create (Insert)
      * Inserts a new score record for the user.
      *
      * @param userId the ID of the user
@@ -40,6 +41,7 @@ public class ScoreDAO {
     }
 
     /**
+     * 2. Read
      * Retrieves all quiz score records for a specific user,
      * ordered by most recent attempts.
      *
@@ -70,6 +72,34 @@ public class ScoreDAO {
     }
 
     /**
+     * 3. Update
+     * Updates the most recent score record for a specific user.
+     * This method identifies the record by finding the maximum date_taken
+     * associated with the given user ID.
+     *
+     * @param userId the ID of the user
+     * @param newScore the updated score value
+     */
+    public void updateScore(int userId, int newScore) {
+        String sql = "UPDATE SCORES SET score = ? " +
+                "WHERE user_id = ? " +
+                "AND date_taken = (SELECT MAX(date_taken) FROM SCORES WHERE user_id = ?)";
+
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+            pstmt.setInt(1, newScore);
+            pstmt.setInt(2, userId);
+            pstmt.setInt(3, userId);
+            pstmt.executeUpdate();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * 4. Delete
      * Deletes all score records associated with a specific user.
      * This method is primarily used for testing purposes.
      *

--- a/src/test/java/org/example/triviagame/ScoreDAOTest.java
+++ b/src/test/java/org/example/triviagame/ScoreDAOTest.java
@@ -11,9 +11,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 
 /**
- * @author Anthony Ou
- * @version 0.1.0
- * @since 4/13/26
+ * @author Anthony Ou, Yachi Feng
+ * @version 0.2.0
+ * @since 4/22/26
  *
  * Unit test for the ScoreDAO class
  */

--- a/src/test/java/org/example/triviagame/ScoreDAOTest.java
+++ b/src/test/java/org/example/triviagame/ScoreDAOTest.java
@@ -1,6 +1,4 @@
 package org.example.triviagame;
-
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -71,5 +69,37 @@ public class ScoreDAOTest{
 
     }
 
+    /**
+     * Tests the update function of ScoreDAO.
+     * Verifies that an existing score can be modified and correctly retrieved.
+     */
+    @Test
+    public void testUpdateScore() {
+        int testUserId = 1;
+        scoreDAO.insertScore(testUserId, 70);
 
+        // Update the score we just inserted
+        scoreDAO.updateScore(testUserId, 95);
+
+        List<ScoreRecord> scores = scoreDAO.getUserScores(testUserId);
+        assertFalse(scores.isEmpty(), "Score list should not be empty.");
+        assertEquals(95, scores.get(0).getScore(), "The most recent score should be updated to 95.");
+    }
+
+    /**
+     * Tests the delete function of ScoreDAO.
+     * Verifies that all score records for a user are removed correctly.
+     */
+    @Test
+    public void testDeleteScores() {
+        int testUserId = 1;
+        scoreDAO.insertScore(testUserId, 88);
+
+        // Action: Delete the scores
+        scoreDAO.deleteScoresByUser(testUserId);
+
+        // Verification: The list should be empty
+        List<ScoreRecord> scores = scoreDAO.getUserScores(testUserId);
+        assertTrue(scores.isEmpty(), "Score list should be empty after deletion.");
+    }
 }


### PR DESCRIPTION
This PR supplements the initial work on ScoreDAO to ensure it fully complies with the project's database testing specifications (at least 3 tests per table: insert, update, delete).

ScoreDAO Enhancements:
- Added the missing updateScore(int userId, int newScore) method to support full CRUD operations.
- Optimized SQL logic to target the most recent score record using MAX(date_taken).

Unit Test Expansion:
- Added testUpdateScore() to verify that score modifications are correctly persisted.
- Added testDeleteScores() as an explicit test case to verify record removal, separate from the tearDown process.

Closes #3